### PR TITLE
Fixed how to specify minSdkVersion

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,6 +74,10 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
+    <config-file target="res/xml/config.xml" parent="/*">
+      <preference name="android-minSdkVersion" value="21" />
+    </config-file>
+
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="libs/cdvnodejsmobile/" />


### PR DESCRIPTION
modified how to specify minSdkVersion in /manifest/uses-sdk because of an error.

## error message

```
Installing "nodejs-mobile-cordova" for android
Failed to install 'nodejs-mobile-cordova': Error: Unable to graft xml at selector "/manifest/uses-sdk" from "/Users/okhiroyuki/Documents/github/RedMobile/platforms/android/app/src/main/AndroidManifest.xml" during config install
    at ConfigFile.graft_child (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigFile.js:117:23)
    at PlatformMunger.apply_file_munge (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:76:43)
    at PlatformMunger._munge_helper (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:219:18)
    at PlatformMunger.add_plugin_changes (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:148:14)
    at /Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/PluginManager.js:121:33
    at _fulfilled (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:854:54)
    at /Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:883:30
    at Promise.promise.promiseDispatch (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:816:13)
    at /Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:877:14
    at runSingle (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:137:13)
Unable to graft xml at selector "/manifest/uses-sdk" from "/Users/okhiroyuki/Documents/github/RedMobile/platforms/android/app/src/main/AndroidManifest.xml" during config install
```