### PR TITLE
fix: remove minSdkVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ $ cordova plugin add nodejs-mobile-cordova
 
 ## Requirements
 
- - Cordova 7.x or higher
+ - Cordova 9.x or higher
  - iOS 11 or higher
- - Android API 21 or higher
+ - Android API 22 or higher
 
 When building an application for the Android platform, make sure you have the [Android NDK](https://developer.android.com/ndk/index.html) installed and the environment variable `ANDROID_NDK_HOME` set, for example:
 ```bash

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,10 +74,6 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
-    <config-file target="res/xml/config.xml" parent="/*">
-      <preference name="android-minSdkVersion" value="21" />
-    </config-file>
-
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="libs/cdvnodejsmobile/" />


### PR DESCRIPTION
Cordova Android 9 removes the specification of 21, since minSdkVersion is now 22.

https://cordova.apache.org/announcements/2020/06/29/cordova-android-9.0.0.html

ref: https://github.com/okhiroyuki/nodejs-mobile-cordova/pull/4#commitcomment-47176239