### PR TITLE
Update nodejs_apis.js

### DIFF
--- a/www/nodejs_apis.js
+++ b/www/nodejs_apis.js
@@ -148,7 +148,7 @@ function start(filename, callback, options) {
 
 function startWithScript(script, callback, options) {
   options = options || {};
-  startEngine([script, options], callback);
+  startEngine("startEngineWithScript", [script, options], callback);
 }
 
 function reset(callback) {


### PR DESCRIPTION
Fixed missing "startEngineWithScript" argument in `nodejs.startEngineWithScript` `startEngine` function