### PR TITLE
fix(android): set default ABI filters only if none are defined

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -40,7 +40,7 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.util.GradleVersion;
 
 cdvPluginPostBuildExtras += { ->
-    if (android.defaultConfig.ndk.abiFilters == null) {
+    if (android.defaultConfig.ndk.abiFilters.isEmpty()) {
       // No abiFilter is defined for the build. Set it to the supported architectures.
       logger.info("nodejs-mobile-cordova detected no ABI filters were set. Will use [\"armeabi-v7a\", \"arm64-v8a\", \"x86_64\"] for ABI filters.");
       android.defaultConfig.ndk.abiFilters = ["armeabi-v7a", "arm64-v8a", "x86_64"] as Set<String>;

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -40,9 +40,11 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.util.GradleVersion;
 
 cdvPluginPostBuildExtras += { ->
-    // Set it to the supported architectures.
-    logger.info("nodejs-mobile-cordova were set [\"armeabi-v7a\", \"arm64-v8a\", \"x86_64\"] for ABI filters.");
-    android.defaultConfig.ndk.abiFilters = ["armeabi-v7a", "arm64-v8a", "x86_64"] as Set<String>;
+    if (android.defaultConfig.ndk.abiFilters == null) {
+      // No abiFilter is defined for the build. Set it to the supported architectures.
+      logger.info("nodejs-mobile-cordova detected no ABI filters were set. Will use [\"armeabi-v7a\", \"arm64-v8a\", \"x86_64\"] for ABI filters.");
+      android.defaultConfig.ndk.abiFilters = ["armeabi-v7a", "arm64-v8a", "x86_64"] as Set<String>;
+    }
 
     // gzip files will cause errors with aapt. Remove them for improved npm compatibility.
     android.aaptOptions.ignoreAssetsPattern += ":!*.gz";


### PR DESCRIPTION
This is the previous behavior from the JaneaSystems branch of nodejs-mobile-cordova (see [this commit](https://github.com/JaneaSystems/nodejs-mobile-cordova/commit/41689bc8a2d89445d792be5e1a977354021a8674#diff-4419737aa2b6937e7d473c0aeac480862903ef67e9d344a5ca4037b3827b1cefR31)). This way it is still possible to override the abiFilters as a user. In the current version the set of abiFilters is fixed.